### PR TITLE
cannot import opencv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(OpenCV REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -27,7 +28,7 @@ add_executable(sensor src/sensor.cpp)
 ament_target_dependencies(sensor rclcpp geometry_msgs)
 
 add_executable(image src/image_publisher.cpp)
-ament_target_dependencies(image rclcpp sensor_msgs)
+ament_target_dependencies(image rclcpp sensor_msgs OpenCV)
 
 add_executable(controller src/controller.cpp)
 ament_target_dependencies(controller rclcpp geometry_msgs)

--- a/src/image_publisher.hpp
+++ b/src/image_publisher.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 
+#include "opencv2/opencv.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
@@ -21,17 +22,63 @@ public:
       this->create_publisher<sensor_msgs::msg::Image>("raw_image", 20);
     timer_ = this->create_wall_timer(
       50ms, std::bind(&ImagePublisher::timer_callback, this));
+
+    frame_id_ = 0;
   }
 
   void timer_callback()
   {
-    const auto message = sensor_msgs::msg::Image();
-    publisher_->publish(message);
+    cv::Mat frame;
+    frame = cv::imread("/src/yahoo.jpg");
+    auto message = std::make_unique<sensor_msgs::msg::Image>();
+    message->is_bigendian = false;
+    convert_frame_to_message(frame, frame_id_++, *message);
+    publisher_->publish(*message);
   }
 
 private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  size_t frame_id_;
+
+  /*
+   * CV array type to ROS sensor_msgs/Image type
+   * https://github.com/ros2/demos/blob/master/image_tools/src/cam2image.cpp
+   */
+  std::string mat_type2encoding(int mat_type)
+  {
+    switch (mat_type)
+    {
+      case CV_8UC1:
+        return "mono8";
+      case CV_8UC3:
+        return "bgr8";
+      case CV_16SC1:
+        return "mono16";
+      case CV_8UC4:
+        return "rgba8";
+      default:
+        throw std::runtime_error("Unsupported encoding type");
+    }
+  }
+
+  /*
+   * Insert CV frame to ROS sensor_msgs/Image
+   * https://github.com/ros2/demos/blob/master/image_tools/src/cam2image.cpp
+   */
+  void convert_frame_to_message(const cv::Mat& frame, size_t frame_id,
+                                sensor_msgs::msg::Image& msg)
+  {
+    // copy cv information into ros message
+    msg.height = frame.rows;
+    msg.width = frame.cols;
+    msg.encoding = mat_type2encoding(frame.type());
+    msg.step = static_cast<sensor_msgs::msg::Image::_step_type>(frame.step);
+    size_t size = frame.step * frame.rows;
+    msg.data.resize(size);
+    memcpy(&msg.data[0], frame.data, size);
+    msg.header.frame_id = std::to_string(frame_id);
+  }
 
 }; // namespace ros2_mock
 


### PR DESCRIPTION
Failed to build opencv

```
root@13a54f4a8dca:/src# colcon build
Starting >>> blackchicken
--- stderr: blackchicken                             
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `cv::String::String(char const*)':
image_publisher.cpp:(.text._ZN2cv6StringC2EPKc[_ZN2cv6StringC5EPKc]+0x4d): undefined reference to `cv::String::allocate(unsigned long)'
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `cv::String::~String()':
image_publisher.cpp:(.text._ZN2cv6StringD2Ev[_ZN2cv6StringD5Ev]+0x14): undefined reference to `cv::String::deallocate()'
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `cv::Mat::~Mat()':
image_publisher.cpp:(.text._ZN2cv3MatD2Ev[_ZN2cv3MatD5Ev]+0x39): undefined reference to `cv::fastFree(void*)'
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `cv::Mat::release()':
image_publisher.cpp:(.text._ZN2cv3Mat7releaseEv[_ZN2cv3Mat7releaseEv]+0x4b): undefined reference to `cv::Mat::deallocate()'
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `cv::Mat::operator=(cv::Mat&&)':
image_publisher.cpp:(.text._ZN2cv3MataSEOS0_[_ZN2cv3MataSEOS0_]+0xe7): undefined reference to `cv::fastFree(void*)'
CMakeFiles/image.dir/src/image_publisher.cpp.o: In function `ros2_mock::ImagePublisher::timer_callback()':
image_publisher.cpp:(.text._ZN9ros2_mock14ImagePublisher14timer_callbackEv[_ZN9ros2_mock14ImagePublisher14timer_callbackEv]+0x60): undefined reference to `cv::imread(cv::String const&, int)'
collect2: error: ld returned 1 exit status
make[2]: *** [image] Error 1
make[1]: *** [CMakeFiles/image.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< blackchicken	[ Exited with code 2 ]
                                
Summary: 0 packages finished [1.68s]
  1 package failed: blackchicken
  1 package had stderr output: blackchicken
```